### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,10 @@
+---
 fixtures:
   repositories:
-     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-     archive: "https://github.com/voxpupuli/puppet-archive.git"
-     docker: "https://github.com/garethr/garethr-docker.git"
-     wget: "https://github.com/maestrodev/puppet-wget.git"
-     apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
+    archive: https://github.com/voxpupuli/puppet-archive.git
+    docker: https://github.com/garethr/garethr-docker.git
+    wget: https://github.com/maestrodev/puppet-wget.git
+    apt: https://github.com/puppetlabs/puppetlabs-apt.git
   symlinks:
     grafana: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in grafana